### PR TITLE
Allow use of quotes in chart title

### DIFF
--- a/wagtail_blocks/templates/wagtail_blocks/chart.html
+++ b/wagtail_blocks/templates/wagtail_blocks/chart.html
@@ -70,7 +70,7 @@
         options: {
                 title: {
                     display: true,
-                    text: '{{value.title}}'
+                    text: '{{value.title|escapejs}}'
                 },
             scales: {
                 yAxes: [{


### PR DESCRIPTION
Example:

ChartBlock with title `Bar chart's` 

displayed as `Bar chart&#x27;s` on the chart canvas. 

Other labels etc tested and appear unaffected.